### PR TITLE
tshark: fix so that package builds for arm and aarch64

### DIFF
--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_VERSION=2.4.2
 TERMUX_PKG_SRCURL=https://github.com/wireshark/wireshark/archive/wireshark-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b9b60b3a23e2f24f0f9a75d67364b8eef649960c9d1926697739825a3a7a9861
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
-TERMUX_PKG_DEPENDS="libnl, openssl, libpcap-dev"
+TERMUX_PKG_DEPENDS="libnl, openssl, libpcap, libpcap-dev"
 # As GUI is not supported by termux we need to disable wireshark
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark"
 

--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -4,7 +4,10 @@ TERMUX_PKG_VERSION=2.4.2
 TERMUX_PKG_SRCURL=https://github.com/wireshark/wireshark/archive/wireshark-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b9b60b3a23e2f24f0f9a75d67364b8eef649960c9d1926697739825a3a7a9861
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
-TERMUX_PKG_DEPENDS="libnl, libnl-dev, openssl,openssl-dev " 
-# As GUI is not supported by termux we need to disable wireshark 
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark" 
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_DEPENDS="libnl, openssl, libpcap-dev"
+# As GUI is not supported by termux we need to disable wireshark
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark"
+
+termux_step_pre_configure () {
+	./autogen.sh
+}

--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -4,7 +4,7 @@ TERMUX_PKG_VERSION=2.4.2
 TERMUX_PKG_SRCURL=https://github.com/wireshark/wireshark/archive/wireshark-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=b9b60b3a23e2f24f0f9a75d67364b8eef649960c9d1926697739825a3a7a9861
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
-TERMUX_PKG_DEPENDS="libnl, openssl, libpcap, libpcap-dev"
+TERMUX_PKG_DEPENDS="libnl, openssl, libpcap, libpcap-dev, libcrypt, libgcrypt-dev, glib"
 # As GUI is not supported by termux we need to disable wireshark
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no --disable-wireshark"
 

--- a/packages/tshark/caputils-ws80211.c.patch
+++ b/packages/tshark/caputils-ws80211.c.patch
@@ -1,0 +1,11 @@
+--- ./caputils/ws80211_utils.c	2017-10-10 17:50:57.000000000 +0000
++++ ../ws80211_utils.c	2017-10-18 08:19:26.903580180 +0000
+@@ -671,7 +671,7 @@
+ 
+ 	/* Update names of user created monitor interfaces */
+ 	while(fgets(line, sizeof(line), fh)) {
+-		t = index(line, ':');
++		t = strchr(line, ':');
+ 		if (!t)
+ 			continue;
+ 		*t = 0;


### PR DESCRIPTION
Fails when building for i686 so still needs more work.